### PR TITLE
Always generate a term URL

### DIFF
--- a/components/class-go-taxonomy.php
+++ b/components/class-go-taxonomy.php
@@ -119,9 +119,10 @@ class GO_Taxonomy
 
 		foreach( $terms as $term )
 		{
-			if ( ! isset( $scheme_url[ $term->taxonomy ] ) )
+			$term_link_url = get_term_link( $term );
+
+			if ( ! isset( $scheme_url[ $term->taxonomy ][ $term->slug ] ) )
 			{
-				$term_link_url = get_term_link( $term );
 				$scheme_url[ $term->taxonomy ] = preg_replace( '#' . $term->slug . '/?#', '', $term_link_url );
 			}// end if
 


### PR DESCRIPTION
The term URL used in `<category>` elements was only being generated on the first term per taxonomy.

Related: https://github.com/GigaOM/gigaom-plugins/pull/1526

See: https://github.com/GigaOM/legacy-pro/issues/2402
