### PR TITLE
The category tag shouldn't have text other than the label

### DIFF
--- a/components/class-go-taxonomy.php
+++ b/components/class-go-taxonomy.php
@@ -135,10 +135,9 @@ class GO_Taxonomy
 			if ( 'atom' == $type )
 			{
 				$categories .= sprintf(
-					'<category scheme="%1$s" term="%2$s" label="%3$s"><![CDATA[%4$s]]></category>' . "\n\t\t",
+					'<category scheme="%1$s" term="%2$s" label="%3$s"/>' . "\n\t\t",
 					esc_url_raw( $scheme_url[ $term->taxonomy ] ),
 					esc_url_raw( $term_link_url ),
-					esc_attr( $term->name ),
 					esc_attr( $term->name )
 				);
 			}// end if


### PR DESCRIPTION
My reference article: http://edward.oconnor.cx/2007/02/representing-tags-in-atom

![screen shot 2014-11-04 at 9 02 17 am](https://cloud.githubusercontent.com/assets/430385/4900744/36205c32-642b-11e4-9a79-b4a8be30d12f.png)

See: https://github.com/GigaOM/gigaom/issues/5883
