### PR TITLE
Remove unused second param

### DIFF
--- a/components/class-go-taxonomy.php
+++ b/components/class-go-taxonomy.php
@@ -111,7 +111,7 @@ class GO_Taxonomy
 	{
 		// Determine if we have some taxonomies to work with
 		$taxonomies = isset( $this->config['the_category_rss_taxonomies'] ) ? $this->config['the_category_rss_taxonomies'] : array();
-		$taxonomies = apply_filters( 'go_taxonomy_rss_taxonomies', $taxonomies, $type );
+		$taxonomies = apply_filters( 'go_taxonomy_rss_taxonomies', $taxonomies );
 
 		if ( empty( $taxonomies ) )
 		{


### PR DESCRIPTION
Applies to https://github.com/GigaOM/gigaom/issues/6579

Remove unused parameter from the filter.

Related: https://github.com/GigaOM/gigaom-plugins/pull/3535
